### PR TITLE
add physics

### DIFF
--- a/client/Player.gd
+++ b/client/Player.gd
@@ -38,7 +38,7 @@ func _process(delta):
 		position = puppet_position
 		velocity = puppet_velocity
 	
-	position += velocity * delta
+	move_and_slide(velocity, Vector2(0,0))
 	
 	if not is_network_master():
 		# It may happen that many frames pass before the controlling player sends

--- a/client/Player.tscn
+++ b/client/Player.tscn
@@ -4,15 +4,16 @@
 [ext_resource path="res://Player.gd" type="Script" id=2]
 
 [sub_resource type="RectangleShape2D" id=1]
+extents = Vector2( 31.6751, 31.8649 )
 
 [node name="Player" type="KinematicBody2D"]
 script = ExtResource( 2 )
 
-[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
-shape = SubResource( 1 )
-
 [node name="Sprite" type="Sprite" parent="."]
 texture = ExtResource( 1 )
+
+[node name="CollisionShape2D" type="CollisionShape2D" parent="."]
+shape = SubResource( 1 )
 
 [node name="NameLabel" type="Label" parent="."]
 margin_left = -31.0


### PR DESCRIPTION
master node for player (a kinematic body) uses move_and_slide physics primitive.  puppet node simply accepts position updates and alters its `position` var, bypassing physics.  dead simple!