### PR TITLE
Calculate move_and_slide in _physics_process

### DIFF
--- a/client/Player.gd
+++ b/client/Player.gd
@@ -15,7 +15,7 @@ func _ready():
 		puppet_position = position
 
 
-func _process(delta):
+func _physics_process(delta):
 	if is_network_master():
 		var move_dir = Vector2()
 		
@@ -46,3 +46,4 @@ func _process(delta):
 		# we will keep jumping back until controlling player sends next position update.
 		# Therefore, we update puppet_pos to minimize jitter problems
 		puppet_position = position
+	

--- a/server/Player.gd
+++ b/server/Player.gd
@@ -11,7 +11,9 @@ func _ready():
 	$NameLabel.text = PlayerNames.get(player_id)
 	puppet_position = position
 	
-func _process(delta):
+# clients are computing their position using
+# _physics_process + move_and_slide()
+func _physics_process(delta):
 	position = puppet_position
 	velocity = puppet_velocity
 	position += velocity * delta


### PR DESCRIPTION
Moves the call site for `_physics_process` as [recommended by the official docs](https://docs.godotengine.org/en/stable/tutorials/physics/physics_introduction.html#physics-process-callback).