### PR TITLE
Link chat focus to player movement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-# NEXT: v0.2.0
+# v0.2.0
 
-If necessary, ChatInput now grabs focus when you press enter.  (#7)
+If necessary, ChatInput now grabs focus when you press enter.  (#7, #8, #9)
 
 # v0.1.1
 

--- a/client/Chat.gd
+++ b/client/Chat.gd
@@ -10,10 +10,9 @@ func _input(event):
 	if event is InputEventKey:
 		if event.pressed and event.scancode == KEY_ENTER:
 			if ChatInput.has_focus():
-				if ChatInput.text.strip_edges() == "":
-					_release_focus()					
-				else:
-					_send_message()
+				if ChatInput.text.strip_edges() != "":
+					_send_message()					
+				_release_focus()
 			else:
 				ChatInput.grab_focus()
 				emit_signal("chat_focus_grabbed")

--- a/client/Chat.gd
+++ b/client/Chat.gd
@@ -1,5 +1,8 @@
 extends Panel
 
+signal chat_focus_grabbed
+signal chat_focus_released
+
 onready var ChatDisplay = $Display
 onready var ChatInput = $Input
 
@@ -8,16 +11,18 @@ func _input(event):
 		if event.pressed and event.scancode == KEY_ENTER:
 			if ChatInput.has_focus():
 				if ChatInput.text.strip_edges() == "":
-					ChatInput.release_focus()
+					_release_focus()					
 				else:
-					send_message()
+					_send_message()
 			else:
 				ChatInput.grab_focus()
+				emit_signal("chat_focus_grabbed")
 		
 		if event.pressed and event.scancode == KEY_ESCAPE and ChatInput.has_focus():
 			ChatInput.release_focus()
+			emit_signal("chat_focus_released")
 
-func send_message():
+func _send_message():
 	var msg = ChatInput.text
 	ChatInput.text = ""
 	var id = get_tree().get_network_unique_id()
@@ -26,3 +31,7 @@ func send_message():
 sync func receive_message(id, msg):
 	ChatDisplay.text += "\n" + PlayerNames.get(id) + ": " + msg
 	ChatDisplay.set_v_scroll(100.0)
+
+func _release_focus():
+	ChatInput.release_focus()
+	emit_signal("chat_focus_released")

--- a/client/Player.gd
+++ b/client/Player.gd
@@ -1,7 +1,5 @@
 extends KinematicBody2D
 
-signal chat_focus_grabbed
-signal chat_focus_released
 
 const SPEED = 300
 const chat_path = NodePath("/root/Chat")
@@ -64,6 +62,8 @@ func _physics_process(delta):
 	
 func _on_chat_focus_grabbed():
 	_allow_input = false
+	rset_unreliable("puppet_position", position)
+	rset_unreliable("puppet_velocity", Vector2.ZERO)
 	
 func _on_chat_focus_released():
 	_allow_input = true

--- a/client/Player.gd
+++ b/client/Player.gd
@@ -1,12 +1,27 @@
 extends KinematicBody2D
 
+signal chat_focus_grabbed
+signal chat_focus_released
+
 const SPEED = 300
+const chat_path = NodePath("/root/Chat")
+
 var velocity = Vector2()
 
 puppet var puppet_position
 puppet var puppet_velocity = Vector2()
 
+# Disallow input when focused in chat
+var _allow_input = true
+
+onready var Chat = get_node(chat_path)
+
+
 func _ready():
+	if Chat != null:
+		Chat.connect("chat_focus_grabbed", self, "_on_chat_focus_grabbed")
+		Chat.connect("chat_focus_released", self, "_on_chat_focus_released")
+	
 	if is_network_master():
 		$NameLabel.text = "You"
 	else:
@@ -16,7 +31,7 @@ func _ready():
 
 
 func _physics_process(delta):
-	if is_network_master():
+	if _allow_input && is_network_master():
 		var move_dir = Vector2()
 		
 		if Input.is_action_pressed("ui_up"):
@@ -47,3 +62,8 @@ func _physics_process(delta):
 		# Therefore, we update puppet_pos to minimize jitter problems
 		puppet_position = position
 	
+func _on_chat_focus_grabbed():
+	_allow_input = false
+	
+func _on_chat_focus_released():
+	_allow_input = true


### PR DESCRIPTION
Resolves #8, and releases focus as soon as you send a message in chat.